### PR TITLE
suggestions to avoid warnings when building

### DIFF
--- a/citation/quellen.bib
+++ b/citation/quellen.bib
@@ -6,7 +6,7 @@
  year = {2015},
  title = {USB complete: The developer's guide},
  address = {Madison, Wisconsin},
- edition = {Fifth edition},
+ edition = {Fifth},
  publisher = {{Lakeview Research}},
  isbn = {978-1-931448-29-1},
  series = {Complete Guides series},

--- a/configuration.tex
+++ b/configuration.tex
@@ -63,6 +63,7 @@
 \usepackage{paralist} % for \begin{compactitem}
 
 
+\usepackage{scrhack} % included because \float@listhead is not supported anymore http://www.bakoma-tex.com/doc/latex/koma-script/scrhack.pdf page 3
 \usepackage{listings}
 \lstset{
     basicstyle=\footnotesize, % Global Code Style
@@ -82,7 +83,7 @@
 %\usepackage{color}
 %\include{listingsstyls}
 
-\usepackage{etex}
+%\usepackage{etex} % etex package is obsolete according to https://tex.stackexchange.com/a/186597/52414
 % \#TODO: Entscheiden welchen Style
 %\bibliographystyle{ieeetr} % ist ohne den Strich
 %\bibliographystyle{IEEETran} % ist mit dem Strich, dafür ausführlicher
@@ -95,11 +96,13 @@
 \usepackage{float}
 \usepackage[abs]{overpic} % Für Unterschrift
 
-\usepackage[binary-units = true ]{siunitx}
+%\usepackage[binary-units = true ]{siunitx} % option binary-units has been removed https://github.com/josephwright/siunitx/blob/main/CHANGELOG.md#removed
+\usepackage{siunitx}
 %\sisetup{scientific-notation = true} % Wissenschaftliche Notation
 \sisetup{exponent-product = \cdot}
-\sisetup{output-product = \cdot} % Das Punkt statt X
-\sisetup{binary-units=true}
+%\sisetup{output-product = \cdot} % Das Punkt statt X % option output-product got replaced with option product-symbol https://texdoc.org/serve/siunitx/0 page 34
+\sisetup{product-symbol= \ensuremath{\cdot}}
+%\sisetup{binary-units=true}
 \sisetup{output-decimal-marker = {,}}
 \sisetup{detect-all} 	% Einstellung das Front für SI gleich Standardfront
 \sisetup{per-mode = symbol}

--- a/content/Vorlage_Content.tex
+++ b/content/Vorlage_Content.tex
@@ -23,7 +23,7 @@ Neben der Richtung eines endpoints, IN oder OUT, werden vier Übertragungsarten 
     \item \textbf{bulk transfer} Für die Übertragung grö{\ss}er Datenmengen ohne zugesicherten Geschwindigkeit oder Latenz über eine data pipe ohne Datenverluste.
     \item \textbf{isochronous transfer}  Für Übertragungen mit zugesicherten Übertragungskapazität über eine data pipe ohne Fehlerbehebung.
 \end{compactitem}
-Welche Übertragungsarten ein Gerät unterstützt, und damit über welche endpoints es verfügt kann frei gewählt werden oder kann einer %\acrshort{ubs} Klassen Spezifikation folgen. Eine solche Spezifikation definiert neben dem Aufbau der endpoints weiter einheitliche Funktionen damit Geräte, einer gleichen Klasse, problemlos ausgetauscht werden können.
+Welche Übertragungsarten ein Gerät unterstützt, und damit über welche endpoints es verfügt kann frei gewählt werden oder kann einer \acrshort{usb} Klassen Spezifikation folgen. Eine solche Spezifikation definiert neben dem Aufbau der endpoints weiter einheitliche Funktionen damit Geräte, einer gleichen Klasse, problemlos ausgetauscht werden können. % typo (ubs instead of usb)
 
 Softwareseitig wird die Übertragung in drei Ebenen unterteilt, diese sind in \autoref{fig:usb_schnittstellen_abstraktion} abgebildet.
 \begin{figure}[h]
@@ -44,7 +44,7 @@ Die \acrshort{usb} Spezifikation definiert vier Arten von endpoints mit der maxi
     \item \textbf{control endpoint} für control Transfers und muss in jedem Gerät vorhanden sein, um Geräteinformation zu übertragen. Die Übertragung sind fehlerbehebend und können, bei High-Speed, bis zu 10\% der Buslast einnehmen.
 \end{compactitem}
 
-Im  device descriptor werden allgemeine Informationen für ein Gerät bereitgestellt, die Datenfelder sind in \autoref{tab:ubs_device_descriptor} aufgetragen.
+Im  device descriptor werden allgemeine Informationen für ein Gerät bereitgestellt, die Datenfelder sind in \autoref{tab:usb_device_descriptor} aufgetragen. % typo (ubs instead of usb)
 \begin{table}[h]
     \centering
     \begin{tabular}{|l|l|}
@@ -65,7 +65,7 @@ Im  device descriptor werden allgemeine Informationen für ein Gerät bereitgest
         \hline
         bMaxPacketSize     & Maximale Packet Größe für endpoint 0               \\
         \hline
-        idVendor           & \acrfull{vid}, vergeben durch \acrshort{usbif})        \\
+        idVendor           & \acrfull{vid}, vergeben durch \acrshort{usbif}        \\ % typo
         \hline
         idProduct          & \acrfull{produkt_id}, vergeben durch den Hersteller   \\
         \hline
@@ -84,3 +84,12 @@ Im  device descriptor werden allgemeine Informationen für ein Gerät bereitgest
     \label{tab:usb_device_descriptor} % #TODO Offset und Size entfernen
 \end{table}
 
+
+% added subsections to avoid warnings because of references in line 39 and line 41
+\subsubsection{Konfigurationsvorgang} \label{sssec:Konfigurationsvorgang}
+
+\acrshort{usb} Konfigurationsvorgang
+
+\subsubsection{USB Überblick} \label{sssec:usb_ueberblick}
+
+\acrshort{usb} Überblick


### PR DESCRIPTION
Hallo Jo5ta, beim Versuch das Latex Template zu bauen, sind bei mir Warnungen aufgetaucht. Hier sind die Änderungen, die ich vorgenommen habe. Dahinter steht jeweils ein Kommentar mit einer Beschreibung, was geändert wurde und warum. Vielleicht könnte das für zukünftige Nutzer des Templates hilfreich sein.

Hinweise:
- Grund für die Änderung in der Datei "citation/quellen.bib": https://www.bibtex.com/f/edition-field/
- Die beiden vorhandenen Bilder im Ordner "content/images" lassen sich nicht verwenden. Es wird der Fehler "libpng error: PNG file corrupted by ASCII conversion" angezeigt.